### PR TITLE
Remove ES6 polyfill from mkdocs configuration

### DIFF
--- a/mkdocs/mkdocs.yml
+++ b/mkdocs/mkdocs.yml
@@ -27,7 +27,6 @@ markdown_extensions:
   - pymdownx.arithmatex:
       generic: true
 extra_javascript:
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
   - assets/javascripts/quiz_evaluation.js
 


### PR DESCRIPTION
Removed polyfill script from extra_javascript section since it inserted malicious code, causing a pop-up asking for credentials, see also:
- https://www.agid.gov.it/index.php/en/agenzia/stampa-e-comunicazione/notizie/2024/06/28/polyfillio-cert-agid-advises-public-administrations-quickly-remove-it-their-sites
- https://github.com/3dgeo-heidelberg/etrainee/pull/98